### PR TITLE
Order history by date on server side before finding uniques

### DIFF
--- a/server/src/controllers/HistoriesController.js
+++ b/server/src/controllers/HistoriesController.js
@@ -16,6 +16,9 @@ module.exports = {
           {
             model: Song
           }
+        ],
+        order: [
+          ['createdAt', 'DESC']
         ]
       })
         .map(history => history.toJSON())


### PR DESCRIPTION
Currently, we're filtering the history for uniques on the server side without any ordering. This could lead to us filtering out the latest histories, and returning older ones.

By sorting the results beforehand, we're guaranteeing keeping the latest history instance for each song.