### PR TITLE
prevent duplicate songs in recently viewed songs table and maintain sort based on view order

### DIFF
--- a/client/src/components/Songs/RecentlyViewedSongs.vue
+++ b/client/src/components/Songs/RecentlyViewedSongs.vue
@@ -34,7 +34,7 @@ export default {
         }
       ],
       pagination: {
-        sortBy: 'createdAt',
+        sortBy: 'updatedAt',
         descending: true
       },
       histories: []

--- a/server/src/models/History.js
+++ b/server/src/models/History.js
@@ -1,5 +1,10 @@
 module.exports = (sequelize, DataTypes) => {
-  const History = sequelize.define('History', {})
+  const History = sequelize.define('History', {
+    viewCount: {
+      type: DataTypes.INTEGER,
+      defaultValue: 1
+    }
+  })
 
   History.associate = function (models) {
     History.belongsTo(models.User)


### PR DESCRIPTION
I added a ViewCount column to the database history table.  When a user views a song and posts to the histories controller, before inserting a new row, the database is queried to see if a history entry already exists for this user/song.  If one is found, the existing entry's view count is incremented by one, automatically modifying the UpdatedAt timestamp, which is what is used to sort the history table on the view.